### PR TITLE
Initial version of the containerinfo object, state and item XSD

### DIFF
--- a/x-linux-containerinfo.xsd
+++ b/x-linux-containerinfo.xsd
@@ -1,0 +1,201 @@
+<?xml version="1.0" encoding="utf-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:oval="http://oval.mitre.org/XMLSchema/oval-common-5" xmlns:oval-def="http://oval.mitre.org/XMLSchema/oval-definitions-5" xmlns:oval-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" xmlns:linux-def="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux" xmlns:linux-sc="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux" xmlns:x-linux-containerinfo="http://oval.mitre.org/XMLSchema/x-linux-containerinfo" xmlns:sch="http://purl.oclc.org/dsdl/schematron" targetNamespace="http://oval.mitre.org/XMLSchema/x-linux-containerinfo" elementFormDefault="qualified" version="5.11">
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-definitions-5" schemaLocation="oval-definitions-schema.xsd"/>
+    <xsd:import namespace="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5" schemaLocation="oval-system-characteristics-schema.xsd"/>
+    <xsd:annotation>
+        <xsd:documentation>The following is a proposal for the experimental linux-def:containerinfo_test and linux-sc:containerinfo_item that will support checking the properties associated with container images.</xsd:documentation>
+        <xsd:appinfo>
+            <schema>Experimental Schema for the Linux systemd Unit Property Test</schema>
+            <version>5.12</version>
+            <date>08/02/2016 12:15:00 PM</date>
+            <terms_of_use>Copyright (c) 2002-2016, The MITRE Corporation. All rights reserved.  The contents of this file are subject to the terms of the OVAL License located at http://oval.mitre.org/oval/about/termsofuse.html. See the OVAL License for the specific language governing permissions and limitations for use of this schema.  When distributing copies of the OVAL Schema, this license header must be included.</terms_of_use>
+            <sch:ns prefix="oval-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5"/>
+            <sch:ns prefix="oval-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5"/>
+            <sch:ns prefix="linux-def" uri="http://oval.mitre.org/XMLSchema/oval-definitions-5#linux"/>
+            <sch:ns prefix="linux-sc" uri="http://oval.mitre.org/XMLSchema/oval-system-characteristics-5#linux"/>
+            <sch:ns prefix="x-linux-containerinfo" uri="http://oval.mitre.org/XMLSchema/x-linux-containerinfo"/>
+            <sch:ns prefix="xsi" uri="http://www.w3.org/2001/XMLSchema-instance"/>
+        </xsd:appinfo>
+    </xsd:annotation>
+    <!-- =============================================================================== -->
+    <!-- ==========================  CONTAINER INFO TEST  ============================== -->
+    <!-- =============================================================================== -->
+    <xsd:element name="containerinfo_test" substitutionGroup="oval-def:test">
+        <xsd:annotation>
+            <xsd:documentation>The containerinfo_test is used to retrieve information about container images in form of properties.. It extends the standard TestType as defined in the oval-definitions-schema and one should refer to the TestType description for more information. The required object element references a containerinfo_object and the optional state element specifies the data to check.</xsd:documentation>
+            <xsd:appinfo>
+                <oval:element_mapping>
+                    <oval:test>containerinfo_test</oval:test>
+                    <oval:object>containerinfo_object</oval:object>
+                    <oval:state>containerinfo_state</oval:state>
+                    <oval:item>containerinfo_item</oval:item>
+                </oval:element_mapping>
+            </xsd:appinfo>
+            <xsd:appinfo>
+                <sch:pattern id="linux-def_containerinfotst">
+                    <sch:rule context="linux-def:containerinfo_test/unix-def:object">
+                        <sch:assert test="@object_ref=ancestor::oval-def:oval_definitions/oval-def:objects/linux-def:containerinfo_object/@id"><sch:value-of select="../@id"/> - the object child element of a containerinfo_test must reference a containerinfo_object</sch:assert>
+                    </sch:rule>
+                    <sch:rule context="linux-def:containerinfo_test/unix-def:state">
+                        <sch:assert test="@state_ref=ancestor::oval-def:oval_definitions/oval-def:states/unix-def:containerinfo_state/@id"><sch:value-of select="../@id"/> - the state child element of a containerinfo_test must reference a containerinfo_state</sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:TestType">
+                    <xsd:sequence>
+                        <xsd:element name="object" type="oval-def:ObjectRefType" />
+                        <xsd:element name="state" type="oval-def:StateRefType" minOccurs="0" maxOccurs="unbounded"/>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:complexType name="ContainerInfoLabelType">
+        <xsd:annotation>
+            <xsd:documentation>Label name and value pair.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="name" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
+            <xsd:element name="value" type="xsd:string" minOccurs="0" maxOccurs="1"></xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:element name="containerinfo_object" substitutionGroup="oval-def:object">
+        <xsd:annotation>
+            <xsd:documentation>The containerinfo_object element is used by a containerinfo_test to define the specific container image to be evaluated. Each object extends the standard ObjectType as defined in the oval-definitions-schema and one should refer to the ObjectType description for more information. The common set element allows complex objects to be created using filters and set logic. Again, please refer to the description of the set element in the oval-definitions-schema.</xsd:documentation>
+            <xsd:appinfo>
+                <sch:pattern id="x-linux-containerinfo_object_verify_filter_state">
+                    <sch:rule context="x-linux-containerinfo:containerinfo_object//oval-def:filter">
+                        <sch:let name="parent_object" value="ancestor::x-linux-containerinfo:containerinfo_object"/>
+                        <sch:let name="parent_object_id" value="$parent_object/@id"/>
+                        <sch:let name="state_ref" value="."/>
+                        <sch:let name="reffed_state" value="ancestor::oval-def:oval_definitions/oval-def:states/*[@id=$state_ref]"/>
+                        <sch:let name="state_name" value="local-name($reffed_state)"/>
+                        <sch:let name="state_namespace" value="namespace-uri($reffed_state)"/>
+                        <sch:assert test="(($state_namespace='http://oval.mitre.org/XMLSchema/x-linux-containerinfo') and ($state_name='containerinfo_state'))">State referenced in filter for <sch:value-of select="name($parent_object)"/> '<sch:value-of select="$parent_object_id"/>' is of the wrong type. </sch:assert>
+                    </sch:rule>
+                </sch:pattern>
+            </xsd:appinfo>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:ObjectType">
+                    <xsd:sequence>
+                        <xsd:choice>
+                            <xsd:element ref="oval-def:set"/>
+                            <xsd:sequence>
+                                <xsd:element name="technology" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>docker|runc|rocket or other container technology types.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="image-id" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1"> <!-- NOTE: Image ID is not as useful as some labels, such as authoritative registry and Version/Release -->
+                                    <xsd:annotation>
+                                        <xsd:documentation>The image ID refers to the local container image handle. For example "4ba75a332f34" is a valid docker container image ID. The ID must be compatible with chosen technology in the technology element.</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="architecture" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                                    <xsd:annotation>
+                                        <xsd:documentation>x86, x86_64, ...</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="signed-by" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="unbounded">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Fingerprints of signatures the top image layer has been signed with. (optional)</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element name="label" type="ContainerInfoLabelType" minOccurs="0" maxOccurs="unbounded">
+                                    <xsd:annotation>
+                                        <xsd:documentation>Container image labels. (optional)</xsd:documentation>
+                                    </xsd:annotation>
+                                </xsd:element>
+                                <xsd:element ref="oval-def:filter" minOccurs="0" maxOccurs="unbounded"/>
+                            </xsd:sequence>
+                        </xsd:choice>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <xsd:element name="containerinfo_state" substitutionGroup="oval-def:state">
+        <xsd:annotation>
+            <xsd:documentation>The containerinfo_state element holds information about properties of a specific container image. Please refer to the individual elements in the schema for more details about what each represents.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-def:StateType">
+                    <xsd:sequence>
+                        <xsd:element name="technology" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>docker|runc|rocket or other container technology types.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image-id" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The image ID refers to the local container image handle. For example "4ba75a332f34" is a valid docker container image ID. The ID must be compatible with chosen technology in the technology element.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>x86, x86_64, ...</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="signed-by" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Fingerprints of signatures the top image layer has been signed with. (optional)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="ContainerInfoLabelType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Container image labels. (optional)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+    <!-- =============================================================================== -->
+    <!-- ==========================  CONTAINER INFO ITEM  ============================== -->
+    <!-- =============================================================================== -->
+    <xsd:element name="containerinfo_item" substitutionGroup="oval-sc:item">
+        <xsd:annotation>
+            <xsd:documentation>This item stores the properties and values of a systemd unit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexType>
+            <xsd:complexContent>
+                <xsd:extension base="oval-sc:ItemType">
+                    <xsd:sequence>
+                        <xsd:element name="technology" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>docker|runc|rocket or other container technology types.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="image-id" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>The image ID refers to the local container image handle. For example "4ba75a332f34" is a valid docker container image ID. The ID must be compatible with chosen technology in the technology element.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="architecture" type="oval-def:EntityObjectStringType" minOccurs="1" maxOccurs="1">
+                            <xsd:annotation>
+                                <xsd:documentation>x86, x86_64, ...</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="signed-by" type="oval-def:EntityObjectStringType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Fingerprints of signatures the top image layer has been signed with. (optional)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="label" type="ContainerInfoLabelType" minOccurs="0" maxOccurs="unbounded">
+                            <xsd:annotation>
+                                <xsd:documentation>Container image labels. (optional)</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:sequence>
+                </xsd:extension>
+            </xsd:complexContent>
+        </xsd:complexType>
+    </xsd:element>
+</xsd:schema>


### PR DESCRIPTION
Request for comments.

I am designing a new OVAL test that queries container image properties. There are two main uses cases of such a test:
- container image CVE feed
  - check that the image is signed and is coming from a trusted source, check the labels to figure out if there is a known vulnerability inside it
- generic container image checking
  - check labels for anti-patterns
  - check that all images are coming from some authoritative registry
  - ...

Personally I am more interested in the first use-case but I want to make the test powerful enough to satisfy both.

Example workflow for the container image CVE feed workflow:
- query all `technology=docker` images with Label `Authoritative_Registry=registry.access.redhat.com` and Label `name=rhel7/sssd`, signed by `$REDHAT_key`
- combine Version and Release labels and compare the images with a states of vulnerable images

This is very similar to the RPM CVE feed workflow. My main issue is how to make this vendor neutral and generic, especially the part about combining Version and Release labels. Other vendors may do this in other ways, these two particular labels don't even have to be present. At the same time I need a simple way to do the piece-wise comparison, a lexical comparison won't do. Any ideas here are welcome.